### PR TITLE
goreleaser: Fix ldflags after project restructure

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,7 +42,7 @@ builds:
       - goos: android
         goarch: amd64
     ldflags:
-      - -s -w -X info.Version={{.Version}} -X info.Commit={{.Commit}} -X info.Date={{ .CommitDate }} -X info.BuiltBy=goreleaser
+      - -s -w -X github.com/OpenIoTHub/gateway-go/info.Version={{.Version}} -X github.com/OpenIoTHub/gateway-go/info.Commit={{.Commit}} -X github.com/OpenIoTHub/gateway-go/info.Date={{ .CommitDate }} -X github.com/OpenIoTHub/gateway-go/info.BuiltBy=goreleaser
 
 archives:
   # use zip for windows archives


### PR DESCRIPTION
👋 Hey, in 8e72672c355ee8aca6079e1ea2697637d8d4d0fc the project was restructured, but the goreleaser config was not adjusted properly.

The recent https://github.com/OpenIoTHub/gateway-go/releases/tag/v0.3.5 binaries are missing the version information:
```
~/Downloads/gateway-go_0.3.5_darwin_arm64|⇒  ./gateway-go --version
gateway-go version
commit:
built at:
built by:
```

It was noticed in 
* https://github.com/Homebrew/homebrew-core/pull/209360

where we're testing also the version output.